### PR TITLE
Change gcc arch to fix floating point instruction errors

### DIFF
--- a/Makefile.isp
+++ b/Makefile.isp
@@ -10,7 +10,7 @@ all: build/Makefile
 build/Makefile:
 	$(MAKE) -f Makefile.isp clean
 	mkdir build
-	cd build; ../configure --prefix=$(ISP_PREFIX) --with-arch=rv32g --with-abi=ilp32
+	cd build; ../configure --prefix=$(ISP_PREFIX) --with-arch=rv32ima --with-abi=ilp32
 
 install:
 	$(MAKE) -C build install


### PR DESCRIPTION
Previously, gcc built the C library with floating point accesses, which caused errors whenever an invalid floating point instruction was used.