### PR TITLE
Fix clean target

### DIFF
--- a/Makefile.isp
+++ b/Makefile.isp
@@ -44,5 +44,6 @@ $(BUILD_DIR)/Makefile:
 install:
 	$(MAKE) -C $(BUILD_DIR) install
 
+clean: BUILD_DIR ?= build-multilib
 clean:
 	$(RM) -r $(BUILD_DIR)


### PR DESCRIPTION
Without a default BUILD_LIB define it tries this command `rm -rf `, which is not as dangerous as it looks, but still not the intended result.